### PR TITLE
Added a configuration option to specify a input_id for the element id.  ...

### DIFF
--- a/app/code/local/Jarlssen/ChooserWidget/Helper/Chooser.php
+++ b/app/code/local/Jarlssen/ChooserWidget/Helper/Chooser.php
@@ -259,7 +259,11 @@ class Jarlssen_ChooserWidget_Helper_Chooser extends Mage_Core_Helper_Abstract
             'required' => $isRequired
         );
 
-        $element = $fieldset->addField($config['input_name'], 'label', $inputConfig);
+        if (!isset($config['input_id'])) {
+            $config['input_id'] = $config['input_name'];
+        }
+
+        $element = $fieldset->addField($config['input_id'], 'label', $inputConfig);
         $element->setValue($dataModel->getData($element->getId()));
         $dataModel->setData($element->getId(),'');
 


### PR DESCRIPTION
...input_name is still used if an input_id is not specified.
